### PR TITLE
Add BCV VES to EUR conversion source

### DIFF
--- a/japb_api/currencies/conversion_sources/ves_to_eur.py
+++ b/japb_api/currencies/conversion_sources/ves_to_eur.py
@@ -12,7 +12,7 @@ class _BcvEurParser(HTMLParser):
     def handle_starttag(self, tag, attrs):
         if tag == "div":
             attrs_dict = dict(attrs)
-            if attrs_dict.get("id") == "dolar":
+            if attrs_dict.get("id") == "euro":
                 self._target_depth = 1
             elif self._target_depth:
                 self._target_depth += 1

--- a/japb_api/currencies/conversion_sources/ves_to_eur.py
+++ b/japb_api/currencies/conversion_sources/ves_to_eur.py
@@ -1,0 +1,59 @@
+import requests
+from html.parser import HTMLParser
+
+
+class _BcvEurParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self._target_depth = 0
+        self._in_strong = False
+        self.value = None
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "div":
+            attrs_dict = dict(attrs)
+            if attrs_dict.get("id") == "dolar":
+                self._target_depth = 1
+            elif self._target_depth:
+                self._target_depth += 1
+        elif tag == "strong" and self._target_depth:
+            self._in_strong = True
+
+    def handle_endtag(self, tag):
+        if tag == "div" and self._target_depth:
+            self._target_depth -= 1
+        elif tag == "strong" and self._in_strong:
+            self._in_strong = False
+
+    def handle_data(self, data):
+        if self._in_strong and self.value is None:
+            stripped = data.strip()
+            if stripped:
+                self.value = stripped
+
+
+class VesToEur:
+    BCV_URL = "https://www.bcv.org.ve/"
+
+    @staticmethod
+    def getLatestRateBCV():
+        try:
+            response = requests.get(VesToEur.BCV_URL, timeout=10)
+        except requests.RequestException:
+            return None
+
+        if response.status_code != 200:
+            return None
+
+        parser = _BcvEurParser()
+        parser.feed(response.text)
+
+        if not parser.value:
+            return None
+
+        normalized_value = parser.value.replace(".", "").replace(",", ".")
+
+        try:
+            return float(normalized_value)
+        except ValueError:
+            return None

--- a/japb_api/currencies/tasks.py
+++ b/japb_api/currencies/tasks.py
@@ -1,5 +1,6 @@
 from japb_api.celery import app
 from japb_api.currencies.models import Currency, CurrencyConversionHistorial
+import japb_api.currencies.conversion_sources.ves_to_eur as ves_to_eur
 import japb_api.currencies.conversion_sources.ves_to_usd as ves_to_usd
 
 
@@ -22,4 +23,14 @@ def update_currency_historial():
             currency_to=Currency.objects.get(name="USD"),
             source="bcv",
             rate=rate_bcv,
+        )
+
+    rate_bcv_eur = ves_to_eur.VesToEur.getLatestRateBCV()
+
+    if rate_bcv_eur:
+        CurrencyConversionHistorial.objects.create(
+            currency_from=Currency.objects.get(name="VES"),
+            currency_to=Currency.objects.get(name="EUR"),
+            source="bcv",
+            rate=rate_bcv_eur,
         )


### PR DESCRIPTION
## Summary
- add a BCV-backed VES to EUR conversion source that scrapes the official website
- include the BCV EUR rate in the currency historial update task

## Testing
- python -m compileall japb_api/currencies

------
https://chatgpt.com/codex/tasks/task_e_68dae1bcc840832693380a130cb0994f